### PR TITLE
[tweet] add exit to shutdown node

### DIFF
--- a/jsk_naoqi_robot/jsk_pepper_startup/nodes/tweet-client.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/nodes/tweet-client.l
@@ -7,4 +7,5 @@
 (defun tweet (str &rest args)
   (ros::publish "/pepper_tweet" (instance std_msgs::String :init :data (apply #'format nil str args))))
 
-(progn (unix:sleep 3) (tweet "おはよう") (ros::spin))
+(progn (unix:sleep 3) (tweet "おはよう"))
+(exit)

--- a/jsk_naoqi_robot/jsk_pepper_startup/nodes/tweet-server.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/nodes/tweet-server.l
@@ -113,3 +113,4 @@
 (ros::subscribe "/pepper_tweet" std_msgs::String #'(lambda (msg) (tweet (send msg :data))))
 (ros::ros-info "subscribing /pepper_tweet")
 (ros::spin)
+(exit)


### PR DESCRIPTION
`jsk_pepper_startup.launch`を実行して落とした時、nodeが残ってしまった。
```
rosnode list

/image_saver
/rosout
/twitter_client
/twitter_server
```
`jsk_pepper_startup.launch`を実行している画面を見ていると、clientの方は無事に終了できていないことに気づいた。必要ない`ros::spin`も含まれている。
```
eustf roseus_c_util ignore __name:=twitter_client
ignore __log:=/home/pepper/.ros/log/791306d6-6faa-11e9-a27f-e86a6433c63f/twitter_client-24.log
```

`exit`を加えて、無事終了できることを確認した。
```
[twitter_client-24] process has finished cleanly
log file: /home/pepper/.ros/log/791306d6-6faa-11e9-a27f-e86a6433c63f/twitter_client-24*.log
```

serverの方は、`ros::spin`したきりだったので、`exit`をつけておいた